### PR TITLE
add 'expand' to topics endpoint queries

### DIFF
--- a/attackerkb_api/api.py
+++ b/attackerkb_api/api.py
@@ -33,8 +33,8 @@ class AttackerKB():
         :param page: An int that set the start page to search from
         :param size: An int that sets how many results per page are returned
         :param **kwargs: A set of Key=Values passed to the function to filter the search.
-                         Must be in this list: 
-                         ["id", "editorId" ,"name" ,"created" , "createdAfter", "createdBefore", "revisionDate" , "revisedAfter", "revisedBefore", "disclosureDate" ,"document", "metadata", "featured", "q", "sort"]
+                         Must be in this list:
+                         ["id", "editorId" ,"name" ,"created" , "createdAfter", "createdBefore", "revisionDate" , "revisedAfter", "revisedBefore", "disclosureDate" ,"document", "metadata", "featured", "q", "sort", "expand"]
 
 
         : return: JSON Object with a list of results.
@@ -46,7 +46,7 @@ class AttackerKB():
             "page": page,
             "size": size
         }
-        valid_keys = ["id", "editorId" ,"name" ,"created" , "createdAfter", "createdBefore", "revisionDate" , "revisedAfter", "revisedBefore", "disclosureDate" ,"document", "metadata", "featured", "q", "sort"]
+        valid_keys = ["id", "editorId" ,"name" ,"created" , "createdAfter", "createdBefore", "revisionDate" , "revisedAfter", "revisedBefore", "disclosureDate" ,"document", "metadata", "featured", "q", "sort", "expand"]
         for key, value in kwargs.items():
             if key in valid_keys:
                 params[key] = value


### PR DESCRIPTION
# Summary
This adds support for the 'expand' parameter on topic queries so that tags can be expanded. I'm not sure why this isn't the default, or why more stuff can't be expanded in the public API, but this is a start :)

https://api.attackerkb.com/v1/api-docs/docs

# Pull request type
Please check the type of change this PR introduces:
- [X] Feature

# Checklist
The following tasks must be completed before a PR will be approved. The [CONTRIBUTING](/CONTRIBUTING.md) document details the requirements for new PRs. Before submitting a PR, each task below must be completed and ticked off.
- [ ] Changelog updated
- [X] Functions, methods, classes etc. are properly documented
- [ ] Tests created for coverage where appropriate
- [X] Documentation files updated where appropriate
- [X] Code is PEP 8 compliant
- [X] Unused and commented-out code removed
- [X] Debug statements and prints removed (exceptions made where justified)
- [X] Modules are structured correctly
